### PR TITLE
Add command throttling to player sessions

### DIFF
--- a/internal/game/server.go
+++ b/internal/game/server.go
@@ -148,6 +148,11 @@ func handleConn(conn net.Conn, world *World, accounts *AccountManager, dispatche
 			p.Output <- Prompt(p)
 			continue
 		}
+		if !p.allowCommand(time.Now()) {
+			p.Output <- Ansi(Style("\r\nYou are sending commands too quickly. Please wait.", AnsiYellow))
+			p.Output <- Prompt(p)
+			continue
+		}
 		if !p.Alive {
 			break
 		}

--- a/internal/game/world.go
+++ b/internal/game/world.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -64,6 +65,28 @@ type Player struct {
 	Alive    bool
 	IsAdmin  bool
 	Channels map[Channel]bool
+	history  []time.Time
+}
+
+const (
+	commandLimit  = 5
+	commandWindow = time.Second
+)
+
+func (p *Player) allowCommand(now time.Time) bool {
+	cutoff := now.Add(-commandWindow)
+	filtered := p.history[:0]
+	for _, t := range p.history {
+		if t.After(cutoff) {
+			filtered = append(filtered, t)
+		}
+	}
+	p.history = filtered
+	if len(p.history) >= commandLimit {
+		return false
+	}
+	p.history = append(p.history, now)
+	return true
 }
 
 type World struct {

--- a/internal/game/world_test.go
+++ b/internal/game/world_test.go
@@ -1,6 +1,9 @@
 package game
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestWorldMoveUnknownRoom(t *testing.T) {
 	w := &World{
@@ -16,5 +19,21 @@ func TestWorldMoveUnknownRoom(t *testing.T) {
 	want := "unknown room: missing"
 	if err.Error() != want {
 		t.Fatalf("unexpected error: got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestPlayerAllowCommandThrottles(t *testing.T) {
+	p := &Player{}
+	base := time.Now()
+	for i := 0; i < commandLimit; i++ {
+		if !p.allowCommand(base.Add(time.Duration(i) * (commandWindow / commandLimit))) {
+			t.Fatalf("command %d should be allowed", i)
+		}
+	}
+	if p.allowCommand(base.Add(commandWindow / 2)) {
+		t.Fatalf("command should have been throttled")
+	}
+	if !p.allowCommand(base.Add(commandWindow + time.Millisecond)) {
+		t.Fatalf("command should be allowed after window")
 	}
 }


### PR DESCRIPTION
## Summary
- track recent command timestamps for each player session and limit execution bursts
- notify players when commands are throttled to discourage flooding
- cover the throttling helper with a unit test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d33f2837c8832a8bc2a3e68fced5ba