### PR TITLE
Add command autocomplete and shortcuts

### DIFF
--- a/commands/move.go
+++ b/commands/move.go
@@ -9,6 +9,7 @@ import (
 var Move = Define(Definition{
 	Name:        "go",
 	Aliases:     []string{"n", "s", "e", "w", "u", "d", "up", "down"},
+	Shortcut:    "g",
 	Usage:       "go <direction>",
 	Description: "move (n/s/e/w/u/d and more)",
 }, func(ctx *Context) bool {


### PR DESCRIPTION
## Summary
- allow command definitions to include shortcuts that register as command triggers
- add prefix and fuzzy matching to dispatch to autocomplete unknown command names
- cover autocomplete behaviour and shortcut registration with new tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d344ba4a14832a9c039cc0acb1f95a