### PR TITLE
Add admin and builder tooling

### DIFF
--- a/commands/admin_builder_test.go
+++ b/commands/admin_builder_test.go
@@ -1,0 +1,231 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"aiMud/internal/game"
+)
+
+func TestBuilderCommandTogglesFlag(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Starting Room",
+			Description: "The central hub.",
+			Exits:       map[string]game.RoomID{},
+		},
+	})
+	admin := newTestPlayer("Admin", "start")
+	admin.IsAdmin = true
+	target := newTestPlayer("Target", "start")
+	world.AddPlayerForTest(admin)
+	world.AddPlayerForTest(target)
+
+	if quit := Dispatch(world, admin, "builder Target on"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	if !target.IsBuilder {
+		t.Fatalf("target should be builder after command")
+	}
+
+	adminMsgs := drainOutput(admin.Output)
+	if len(adminMsgs) == 0 || !strings.Contains(adminMsgs[len(adminMsgs)-1], "Target is now a builder") {
+		t.Fatalf("unexpected admin output: %v", adminMsgs)
+	}
+	targetMsgs := drainOutput(target.Output)
+	sawNotice := false
+	for _, msg := range targetMsgs {
+		if strings.Contains(msg, "You are now a builder") {
+			sawNotice = true
+		}
+	}
+	if !sawNotice {
+		t.Fatalf("target did not receive builder notice: %v", targetMsgs)
+	}
+
+	if quit := Dispatch(world, admin, "builder Target off"); quit {
+		t.Fatalf("dispatch returned true on disable")
+	}
+	if target.IsBuilder {
+		t.Fatalf("target should not be builder after disable")
+	}
+}
+
+func TestGotoRequiresBuilder(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{"east": "second"},
+		},
+		"second": {
+			ID:          "second",
+			Title:       "Second",
+			Description: "Second room.",
+			Exits:       map[string]game.RoomID{"west": "start"},
+		},
+	})
+	player := newTestPlayer("Traveler", "start")
+	world.AddPlayerForTest(player)
+
+	if quit := Dispatch(world, player, "goto second"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	if player.Room != "start" {
+		t.Fatalf("player should not have moved, room = %s", player.Room)
+	}
+	msgs := drainOutput(player.Output)
+	sawWarning := false
+	for _, msg := range msgs {
+		if strings.Contains(msg, "Only builders or admins may use goto") {
+			sawWarning = true
+		}
+	}
+	if !sawWarning {
+		t.Fatalf("expected warning message, got %v", msgs)
+	}
+}
+
+func TestGotoMovesBuilder(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{"east": "second"},
+		},
+		"second": {
+			ID:          "second",
+			Title:       "Second",
+			Description: "Second room.",
+			Exits:       map[string]game.RoomID{"west": "start"},
+		},
+	})
+	builder := newTestPlayer("Builder", "start")
+	builder.IsBuilder = true
+	observer := newTestPlayer("Watcher", "second")
+	world.AddPlayerForTest(builder)
+	world.AddPlayerForTest(observer)
+
+	if quit := Dispatch(world, builder, "goto second"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	if builder.Room != "second" {
+		t.Fatalf("builder.Room = %s, want second", builder.Room)
+	}
+
+	builderMsgs := drainOutput(builder.Output)
+	sawRoom := false
+	for _, msg := range builderMsgs {
+		if strings.Contains(msg, "Second room.") {
+			sawRoom = true
+		}
+	}
+	if !sawRoom {
+		t.Fatalf("builder did not see destination room: %v", builderMsgs)
+	}
+
+	observerMsgs := drainOutput(observer.Output)
+	sawArrival := false
+	for _, msg := range observerMsgs {
+		if strings.Contains(msg, "appears in a shimmer of light") {
+			sawArrival = true
+		}
+	}
+	if !sawArrival {
+		t.Fatalf("observer did not see arrival message: %v", observerMsgs)
+	}
+}
+
+func TestSummonMovesTarget(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{"east": "second"},
+		},
+		"second": {
+			ID:          "second",
+			Title:       "Second",
+			Description: "Second room.",
+			Exits:       map[string]game.RoomID{"west": "start"},
+		},
+	})
+	admin := newTestPlayer("Admin", "start")
+	admin.IsAdmin = true
+	target := newTestPlayer("Target", "second")
+	world.AddPlayerForTest(admin)
+	world.AddPlayerForTest(target)
+
+	if quit := Dispatch(world, admin, "summon Target"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	if target.Room != "start" {
+		t.Fatalf("target.Room = %s, want start", target.Room)
+	}
+
+	adminMsgs := drainOutput(admin.Output)
+	sawSummon := false
+	for _, msg := range adminMsgs {
+		if strings.Contains(msg, "You summon Target to your side") {
+			sawSummon = true
+		}
+	}
+	if !sawSummon {
+		t.Fatalf("admin did not receive confirmation: %v", adminMsgs)
+	}
+
+	targetMsgs := drainOutput(target.Output)
+	sawNotice := false
+	for _, msg := range targetMsgs {
+		if strings.Contains(msg, "You are summoned by Admin") {
+			sawNotice = true
+		}
+	}
+	if !sawNotice {
+		t.Fatalf("target did not receive summon notice: %v", targetMsgs)
+	}
+}
+
+func TestWhereListsLocations(t *testing.T) {
+	world := game.NewWorldWithRooms(map[game.RoomID]*game.Room{
+		"start": {
+			ID:          "start",
+			Title:       "Start",
+			Description: "Start room.",
+			Exits:       map[string]game.RoomID{},
+		},
+		"second": {
+			ID:          "second",
+			Title:       "Second",
+			Description: "Second room.",
+			Exits:       map[string]game.RoomID{},
+		},
+	})
+	builder := newTestPlayer("Builder", "start")
+	builder.IsBuilder = true
+	other := newTestPlayer("Other", "second")
+	world.AddPlayerForTest(builder)
+	world.AddPlayerForTest(other)
+
+	if quit := Dispatch(world, builder, "where"); quit {
+		t.Fatalf("dispatch returned true, want false")
+	}
+	msgs := drainOutput(builder.Output)
+	sawHeader := false
+	sawOther := false
+	for _, msg := range msgs {
+		if strings.Contains(msg, "Player locations") {
+			sawHeader = true
+		}
+		if strings.Contains(msg, "Other") && strings.Contains(msg, "[second]") {
+			sawOther = true
+		}
+	}
+	if !sawHeader || !sawOther {
+		t.Fatalf("unexpected output: %v", msgs)
+	}
+}

--- a/commands/builder.go
+++ b/commands/builder.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Builder = Define(Definition{
+	Name:        "builder",
+	Usage:       "builder <player> <on|off>",
+	Description: "grant or revoke builder rights (admin only)",
+}, func(ctx *Context) bool {
+	if !ctx.Player.IsAdmin {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly admins may manage builders.", game.AnsiYellow))
+		return false
+	}
+	parts := strings.Fields(ctx.Arg)
+	if len(parts) != 2 {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: builder <player> <on|off>", game.AnsiYellow))
+		return false
+	}
+	targetName := parts[0]
+	toggle := strings.ToLower(parts[1])
+	var enable bool
+	switch toggle {
+	case "on", "enable", "enabled", "true", "grant":
+		enable = true
+	case "off", "disable", "disabled", "false", "revoke":
+		enable = false
+	default:
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: builder <player> <on|off>", game.AnsiYellow))
+		return false
+	}
+	target, err := ctx.World.SetBuilder(targetName, enable)
+	if err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	state := "no longer"
+	if enable {
+		state = "now"
+	}
+	ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\n%s is %s a builder.", game.HighlightName(target.Name), state))
+	notice := "\r\nYou are now a builder."
+	if !enable {
+		notice = "\r\nYou are no longer a builder."
+	}
+	target.Output <- game.Ansi(notice)
+	return false
+})

--- a/commands/goto.go
+++ b/commands/goto.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Goto = Define(Definition{
+	Name:        "goto",
+	Usage:       "goto <room>",
+	Description: "teleport to a room (builders/admins only)",
+}, func(ctx *Context) bool {
+	if !ctx.Player.IsAdmin && !ctx.Player.IsBuilder {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly builders or admins may use goto.", game.AnsiYellow))
+		return false
+	}
+	target := strings.TrimSpace(ctx.Arg)
+	if target == "" {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: goto <room>", game.AnsiYellow))
+		return false
+	}
+	roomID := game.RoomID(target)
+	if _, ok := ctx.World.GetRoom(roomID); !ok {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nNo such room.", game.AnsiYellow))
+		return false
+	}
+	prev := ctx.Player.Room
+	if prev == roomID {
+		game.EnterRoom(ctx.World, ctx.Player, "")
+		return false
+	}
+	if err := ctx.World.MoveToRoom(ctx.Player, roomID); err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	ctx.World.BroadcastToRoom(prev, game.Ansi(fmt.Sprintf("\r\n%s vanishes in a shimmer of light.", game.HighlightName(ctx.Player.Name))), ctx.Player)
+	ctx.World.BroadcastToRoom(roomID, game.Ansi(fmt.Sprintf("\r\n%s appears in a shimmer of light.", game.HighlightName(ctx.Player.Name))), ctx.Player)
+	game.EnterRoom(ctx.World, ctx.Player, "")
+	return false
+})

--- a/commands/summon.go
+++ b/commands/summon.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Summon = Define(Definition{
+	Name:        "summon",
+	Usage:       "summon <player>",
+	Description: "summon a player to you (admin only)",
+}, func(ctx *Context) bool {
+	if !ctx.Player.IsAdmin {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly admins may summon players.", game.AnsiYellow))
+		return false
+	}
+	targetName := strings.TrimSpace(ctx.Arg)
+	if targetName == "" {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nUsage: summon <player>", game.AnsiYellow))
+		return false
+	}
+	target, ok := ctx.World.FindPlayer(targetName)
+	if !ok {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nThey are not online.", game.AnsiYellow))
+		return false
+	}
+	if target == ctx.Player {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nYou cannot summon yourself.", game.AnsiYellow))
+		return false
+	}
+	if target.Room == ctx.Player.Room {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nThey are already here.", game.AnsiYellow))
+		return false
+	}
+	previous := target.Room
+	if err := ctx.World.MoveToRoom(target, ctx.Player.Room); err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	ctx.World.BroadcastToRoom(previous, game.Ansi(fmt.Sprintf("\r\n%s is yanked away by unseen forces.", game.HighlightName(target.Name))), target)
+	ctx.World.BroadcastToRoom(ctx.Player.Room, game.Ansi(fmt.Sprintf("\r\n%s is summoned by %s.", game.HighlightName(target.Name), game.HighlightName(ctx.Player.Name))), target)
+	target.Output <- game.Ansi(fmt.Sprintf("\r\nYou are summoned by %s.", game.HighlightName(ctx.Player.Name)))
+	game.EnterRoom(ctx.World, target, "")
+	ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou summon %s to your side.", game.HighlightName(target.Name)))
+	return false
+})

--- a/commands/where.go
+++ b/commands/where.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Where = Define(Definition{
+	Name:        "where",
+	Usage:       "where",
+	Description: "show player locations (builders/admins only)",
+}, func(ctx *Context) bool {
+	if !ctx.Player.IsAdmin && !ctx.Player.IsBuilder {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nOnly builders or admins may use where.", game.AnsiYellow))
+		return false
+	}
+	locations := ctx.World.PlayerLocations()
+	if len(locations) == 0 {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nNo players are currently connected.", game.AnsiYellow))
+		return false
+	}
+	var builder strings.Builder
+	builder.WriteString(game.Style("\r\nPlayer locations:\r\n", game.AnsiBold, game.AnsiUnderline))
+	for _, loc := range locations {
+		roomName := "Unknown"
+		if room, ok := ctx.World.GetRoom(loc.Room); ok {
+			roomName = room.Title
+		}
+		builder.WriteString(fmt.Sprintf("  %-18s - %s [%s]\r\n", game.HighlightName(loc.Name), roomName, loc.Room))
+	}
+	ctx.Player.Output <- game.Ansi(builder.String())
+	return false
+})


### PR DESCRIPTION
## Summary
- add admin tooling to summon players and grant builder rights
- add builder commands for teleporting and locating online players
- extend world state helpers to support role checks and include tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d34ac2e2a8832a96e59511bbee3879