### PR TITLE
Add recall and home binding commands

### DIFF
--- a/commands/recall.go
+++ b/commands/recall.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+
+	"aiMud/internal/game"
+)
+
+var Recall = Define(Definition{
+	Name:        "recall",
+	Usage:       "recall",
+	Description: "return to your bound home",
+}, func(ctx *Context) bool {
+	destination := ctx.Player.Home
+	if destination == "" {
+		destination = game.StartRoom
+	}
+	if destination == ctx.Player.Room {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nYou are already home.", game.AnsiYellow))
+		return false
+	}
+	if _, ok := ctx.World.GetRoom(destination); !ok {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nYour home has been lost to the void.", game.AnsiYellow))
+		return false
+	}
+	prev := ctx.Player.Room
+	if err := ctx.World.MoveToRoom(ctx.Player, destination); err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	ctx.World.BroadcastToRoom(prev, game.Ansi(fmt.Sprintf("\r\n%s is enveloped in a flash of light and vanishes.", game.HighlightName(ctx.Player.Name))), ctx.Player)
+	ctx.World.BroadcastToRoom(destination, game.Ansi(fmt.Sprintf("\r\n%s arrives in a flash of light.", game.HighlightName(ctx.Player.Name))), ctx.Player)
+	ctx.Player.Output <- game.Ansi("\r\nYou answer the call of home.")
+	game.EnterRoom(ctx.World, ctx.Player, "")
+	return false
+})

--- a/commands/sethome.go
+++ b/commands/sethome.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var SetHome = Define(Definition{
+	Name:        "sethome",
+	Usage:       "sethome",
+	Description: "bind your recall point to the current room",
+}, func(ctx *Context) bool {
+	roomID := ctx.Player.Room
+	room, ok := ctx.World.GetRoom(roomID)
+	if !ok {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\nYou cannot bind yourself here.", game.AnsiYellow))
+		return false
+	}
+	if err := ctx.World.SetHome(ctx.Player, roomID); err != nil {
+		ctx.Player.Output <- game.Ansi(game.Style("\r\n"+err.Error(), game.AnsiYellow))
+		return false
+	}
+	destination := string(roomID)
+	if room != nil && strings.TrimSpace(room.Title) != "" {
+		destination = room.Title
+	}
+	ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou attune yourself to %s.", game.Style(destination, game.AnsiCyan, game.AnsiBold)))
+	return false
+})

--- a/internal/game/world_test.go
+++ b/internal/game/world_test.go
@@ -56,6 +56,9 @@ func TestAccountManagerProfilePersistence(t *testing.T) {
 	if profile.Room != StartRoom {
 		t.Fatalf("expected default room %q, got %q", StartRoom, profile.Room)
 	}
+	if profile.Home != StartRoom {
+		t.Fatalf("expected default home %q, got %q", StartRoom, profile.Home)
+	}
 	for _, channel := range AllChannels() {
 		if !profile.Channels[channel] {
 			t.Fatalf("expected channel %s to default to enabled", channel)
@@ -64,6 +67,7 @@ func TestAccountManagerProfilePersistence(t *testing.T) {
 
 	updated := PlayerProfile{
 		Room: "lobby",
+		Home: "lobby",
 		Channels: map[Channel]bool{
 			ChannelSay:     true,
 			ChannelWhisper: false,
@@ -79,6 +83,9 @@ func TestAccountManagerProfilePersistence(t *testing.T) {
 	if profile.Room != updated.Room {
 		t.Fatalf("expected room %q, got %q", updated.Room, profile.Room)
 	}
+	if profile.Home != updated.Home {
+		t.Fatalf("expected home %q, got %q", updated.Home, profile.Home)
+	}
 	for channel, want := range updated.Channels {
 		if got := profile.Channels[channel]; got != want {
 			t.Fatalf("channel %s: got %t, want %t", channel, got, want)
@@ -92,6 +99,9 @@ func TestAccountManagerProfilePersistence(t *testing.T) {
 	profile = reloaded.Profile("alice")
 	if profile.Room != updated.Room {
 		t.Fatalf("expected persisted room %q, got %q", updated.Room, profile.Room)
+	}
+	if profile.Home != updated.Home {
+		t.Fatalf("expected persisted home %q, got %q", updated.Home, profile.Home)
 	}
 	for channel, want := range updated.Channels {
 		if got := profile.Channels[channel]; got != want {
@@ -116,13 +126,16 @@ func TestAccountManagerLoadLegacyFormat(t *testing.T) {
 	if profile.Room != StartRoom {
 		t.Fatalf("legacy profile should default to %q, got %q", StartRoom, profile.Room)
 	}
+	if profile.Home != StartRoom {
+		t.Fatalf("legacy profile should default home to %q, got %q", StartRoom, profile.Home)
+	}
 	for _, channel := range AllChannels() {
 		if !profile.Channels[channel] {
 			t.Fatalf("legacy profile channel %s should default to enabled", channel)
 		}
 	}
 
-	desired := PlayerProfile{Room: "garden", Channels: defaultChannelSettings()}
+	desired := PlayerProfile{Room: "garden", Home: "garden", Channels: defaultChannelSettings()}
 	if err := manager.SaveProfile("legacy", desired); err != nil {
 		t.Fatalf("SaveProfile legacy: %v", err)
 	}
@@ -160,6 +173,9 @@ func TestWorldPersistsState(t *testing.T) {
 	if saved.Room != "hall" {
 		t.Fatalf("expected room 'hall', got %q", saved.Room)
 	}
+	if saved.Home != StartRoom {
+		t.Fatalf("expected home to remain %q, got %q", StartRoom, saved.Home)
+	}
 
 	world.SetChannel(player, ChannelWhisper, false)
 	saved = manager.Profile("traveler")
@@ -168,5 +184,43 @@ func TestWorldPersistsState(t *testing.T) {
 	}
 	if !saved.Channels[ChannelSay] {
 		t.Fatalf("say channel should remain enabled")
+	}
+}
+
+func TestWorldSetHomePersists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "accounts.json")
+
+	manager, err := NewAccountManager(path)
+	if err != nil {
+		t.Fatalf("NewAccountManager: %v", err)
+	}
+	if err := manager.Register("traveler", "password123"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	rooms := map[RoomID]*Room{
+		StartRoom: {ID: StartRoom, Exits: map[string]RoomID{"east": "hall"}},
+		"hall":    {ID: "hall", Exits: map[string]RoomID{"west": StartRoom}},
+	}
+	world := NewWorldWithRooms(rooms)
+	world.AttachAccountManager(manager)
+
+	profile := manager.Profile("traveler")
+	player, err := world.addPlayer("traveler", nil, false, profile)
+	if err != nil {
+		t.Fatalf("addPlayer: %v", err)
+	}
+	player.Room = "hall"
+	if err := world.SetHome(player, "hall"); err != nil {
+		t.Fatalf("SetHome: %v", err)
+	}
+
+	saved := manager.Profile("traveler")
+	if saved.Home != "hall" {
+		t.Fatalf("expected home 'hall', got %q", saved.Home)
+	}
+	if saved.Room != player.Room {
+		t.Fatalf("expected room %q, got %q", player.Room, saved.Room)
 	}
 }


### PR DESCRIPTION
## Summary
- add player home location persistence and expose setters on the world
- implement `sethome` and `recall` player commands with messaging and coverage
- extend tests for command behavior and account persistence

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d34fe9420c832aaa9e79cc82de6b47