### PR TITLE
Add room items and player inventory mechanics

### DIFF
--- a/commands/drop.go
+++ b/commands/drop.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Drop = Define(Definition{
+	Name:        "drop",
+	Usage:       "drop <item>",
+	Description: "place a carried item in the room",
+}, func(ctx *Context) bool {
+	target := strings.TrimSpace(ctx.Arg)
+	if target == "" {
+		ctx.Player.Output <- game.Ansi("\r\nDrop what?")
+		return false
+	}
+	item, err := ctx.World.DropItem(ctx.Player, target)
+	switch {
+	case err == nil:
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou drop %s.", game.HighlightItemName(item.Name)))
+		ctx.World.BroadcastToRoom(ctx.Player.Room, game.Ansi(fmt.Sprintf("\r\n%s drops %s.", game.HighlightName(ctx.Player.Name), game.HighlightItemName(item.Name))), ctx.Player)
+	case errors.Is(err, game.ErrItemNotCarried):
+		ctx.Player.Output <- game.Ansi("\r\nYou aren't carrying that.")
+	default:
+		ctx.Player.Output <- game.Ansi("\r\n" + err.Error())
+	}
+	return false
+})

--- a/commands/get.go
+++ b/commands/get.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Get = Define(Definition{
+	Name:        "get",
+	Aliases:     []string{"take", "pickup"},
+	Usage:       "get <item>",
+	Description: "pick up an item in the room",
+}, func(ctx *Context) bool {
+	target := strings.TrimSpace(ctx.Arg)
+	if target == "" {
+		ctx.Player.Output <- game.Ansi("\r\nGet what?")
+		return false
+	}
+	item, err := ctx.World.TakeItem(ctx.Player, target)
+	switch {
+	case err == nil:
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou pick up %s.", game.HighlightItemName(item.Name)))
+		ctx.World.BroadcastToRoom(ctx.Player.Room, game.Ansi(fmt.Sprintf("\r\n%s picks up %s.", game.HighlightName(ctx.Player.Name), game.HighlightItemName(item.Name))), ctx.Player)
+	case errors.Is(err, game.ErrItemNotFound):
+		ctx.Player.Output <- game.Ansi("\r\nYou don't see that here.")
+	default:
+		ctx.Player.Output <- game.Ansi("\r\n" + err.Error())
+	}
+	return false
+})

--- a/commands/inventory.go
+++ b/commands/inventory.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"aiMud/internal/game"
+)
+
+var Inventory = Define(Definition{
+	Name:        "inventory",
+	Aliases:     []string{"inv", "i"},
+	Usage:       "inventory",
+	Description: "list items you are carrying",
+}, func(ctx *Context) bool {
+	items := ctx.World.PlayerInventory(ctx.Player)
+	if len(items) == 0 {
+		ctx.Player.Output <- game.Ansi("\r\nYou aren't carrying anything.")
+		return false
+	}
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = game.HighlightItemName(item.Name)
+	}
+	ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou are carrying: %s", strings.Join(names, ", ")))
+	return false
+})

--- a/commands/look.go
+++ b/commands/look.go
@@ -28,5 +28,12 @@ var Look = Define(Definition{
 		colored := game.HighlightNames(seen)
 		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nYou see: %s", strings.Join(colored, ", ")))
 	}
+	if items := ctx.World.RoomItems(ctx.Player.Room); len(items) > 0 {
+		names := make([]string, len(items))
+		for i, item := range items {
+			names[i] = game.HighlightItemName(item.Name)
+		}
+		ctx.Player.Output <- game.Ansi(fmt.Sprintf("\r\nOn the ground: %s", strings.Join(names, ", ")))
+	}
 	return false
 })

--- a/data/areas/garden.json
+++ b/data/areas/garden.json
@@ -11,7 +11,17 @@
         "n": "start",
         "s": "moonpool",
         "w": "root_caves"
-      }
+      },
+      "items": [
+        {
+          "name": "Luminous Petal",
+          "description": "It sheds soft light, brightening when held near hidden paths."
+        },
+        {
+          "name": "Vial of Dew",
+          "description": "The droplets chime like tiny bells whenever danger nears."
+        }
+      ]
     },
     {
       "id": "glasshouse",

--- a/data/areas/library.json
+++ b/data/areas/library.json
@@ -10,7 +10,17 @@
         "n": "astral_gallery",
         "s": "start",
         "u": "observatory"
-      }
+      },
+      "items": [
+        {
+          "name": "Whispering Quill",
+          "description": "It trembles with unscribed ideas, eager to note your discoveries."
+        },
+        {
+          "name": "Star Chart",
+          "description": "Constellations rearrange themselves to trace paths through the stacks."
+        }
+      ]
     },
     {
       "id": "scriptorium",

--- a/data/areas/market.json
+++ b/data/areas/market.json
@@ -11,7 +11,17 @@
         "n": "parade",
         "s": "harbor",
         "w": "clocktower"
-      }
+      },
+      "items": [
+        {
+          "name": "Sealed Trade Ledger",
+          "description": "Wax sigils glow faintly, promising fortunes to whoever breaks the seal."
+        },
+        {
+          "name": "String of Chimes",
+          "description": "Each bell rings a different currency when shaken."
+        }
+      ]
     },
     {
       "id": "clocktower",

--- a/data/areas/start.json
+++ b/data/areas/start.json
@@ -11,6 +11,16 @@
         "s": "garden",
         "w": "market"
       },
+      "items": [
+        {
+          "name": "Weathered Compass",
+          "description": "Its needle spins lazily, pointing toward adventures yet untaken."
+        },
+        {
+          "name": "Folded Map",
+          "description": "Ink sketches reveal hints about the four neighboring districts."
+        }
+      ],
       "npcs": [
         {
           "name": "Stone Guide",

--- a/data/areas/workshop.json
+++ b/data/areas/workshop.json
@@ -11,7 +11,17 @@
         "s": "atelier_dormitory",
         "u": "loft",
         "w": "start"
-      }
+      },
+      "items": [
+        {
+          "name": "Clockwork Beetle",
+          "description": "Tiny gears whir as it folds into a pocket-sized multitool."
+        },
+        {
+          "name": "Soldering Wand",
+          "description": "Its tip glows when it senses an unfinished invention."
+        }
+      ]
     },
     {
       "id": "gearworks",

--- a/internal/game/ansi.go
+++ b/internal/game/ansi.go
@@ -41,6 +41,11 @@ func HighlightNPCName(name string) string {
 	return Style(name, AnsiBold, AnsiMagenta)
 }
 
+// HighlightItemName formats item names consistently.
+func HighlightItemName(name string) string {
+	return Style(name, AnsiBold, AnsiYellow)
+}
+
 // Trim normalises a telnet input line.
 func Trim(s string) string {
 	return strings.TrimSpace(strings.ReplaceAll(s, "\r", ""))

--- a/internal/game/rooms.go
+++ b/internal/game/rooms.go
@@ -27,6 +27,13 @@ func EnterRoom(world *World, p *Player, via string) {
 		colored := HighlightNames(seen)
 		p.Output <- Ansi(fmt.Sprintf("\r\nYou see: %s", strings.Join(colored, ", ")))
 	}
+	if items := world.RoomItems(p.Room); len(items) > 0 {
+		names := make([]string, len(items))
+		for i, item := range items {
+			names[i] = HighlightItemName(item.Name)
+		}
+		p.Output <- Ansi(fmt.Sprintf("\r\nOn the ground: %s", strings.Join(names, ", ")))
+	}
 	if len(r.NPCs) > 0 {
 		for _, npc := range r.NPCs {
 			if strings.TrimSpace(npc.AutoGreet) == "" {

--- a/internal/game/rooms_test.go
+++ b/internal/game/rooms_test.go
@@ -85,3 +85,36 @@ func TestEnterRoomTriggersNPCGreeting(t *testing.T) {
 		t.Fatalf("NPC greeting missing text: %q", greet)
 	}
 }
+
+func TestEnterRoomListsItems(t *testing.T) {
+	world := &World{
+		rooms: map[RoomID]*Room{
+			"start": {
+				ID:          "start",
+				Title:       "Item Room",
+				Description: "A room stocked with treasures.",
+				Exits:       map[string]RoomID{},
+				Items: []Item{
+					{Name: "Lantern"},
+					{Name: "Rope"},
+				},
+			},
+		},
+		players: make(map[string]*Player),
+	}
+	player := &Player{
+		Name:   "Hero",
+		Room:   "start",
+		Output: make(chan string, 4),
+		Alive:  true,
+	}
+	world.players[player.Name] = player
+
+	EnterRoom(world, player, "")
+
+	<-player.Output // room description
+	items := <-player.Output
+	if !strings.Contains(items, "Lantern") || !strings.Contains(items, "Rope") {
+		t.Fatalf("expected item list to mention Lantern and Rope, got %q", items)
+	}
+}


### PR DESCRIPTION
## Summary
- add an Item model with world helpers for room contents and player inventory management
- surface items in room descriptions and via new get/drop/inventory commands
- seed starting areas with tangible items and cover the new mechanics with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d362555c4c832a9e7b7302de1d06f1