### PR TITLE
Support partial name matching for players and items

### DIFF
--- a/internal/game/match.go
+++ b/internal/game/match.go
@@ -1,0 +1,48 @@
+package game
+
+import "strings"
+
+// uniqueMatch attempts to resolve the provided target string against a slice of
+// candidate names. It performs a case-insensitive comparison, supports prefix
+// matching, and optionally considers word-level prefixes. The function returns
+// the index of the uniquely matched candidate and true. If no match or an
+// ambiguous match is found, it returns -1 and false.
+func uniqueMatch(target string, names []string, matchWords bool) (int, bool) {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return -1, false
+	}
+	normalized := strings.ToLower(trimmed)
+
+	partial := -1
+	ambiguous := false
+	for i, name := range names {
+		candidate := strings.ToLower(strings.TrimSpace(name))
+		if candidate == normalized {
+			return i, true
+		}
+
+		match := strings.HasPrefix(candidate, normalized)
+		if !match && matchWords {
+			for _, word := range strings.Fields(candidate) {
+				if strings.HasPrefix(word, normalized) {
+					match = true
+					break
+				}
+			}
+		}
+
+		if match {
+			if partial != -1 {
+				ambiguous = true
+				continue
+			}
+			partial = i
+		}
+	}
+
+	if partial != -1 && !ambiguous {
+		return partial, true
+	}
+	return -1, false
+}


### PR DESCRIPTION
## Summary
- add a shared name-matching helper that supports case-insensitive prefix searches and optional word matching
- allow world item lookups to accept partial object names for take/drop operations
- enhance player lookup to resolve unique partial prefixes and cover the new behaviour with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d37409d710832aae6b98bbac88d8de